### PR TITLE
fix: add org id to the project schema

### DIFF
--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -573,6 +573,7 @@ export const formProjectSchemaLiteral = {
   },
   required: [
     "id",
+    "orgId",
     "name",
     "company",
     "description",


### PR DESCRIPTION
add org id to the project schmea 
(formProjectSchemaLitral)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new required field, "orgId", to project forms. Users must now provide an organization ID (up to 50 characters) when submitting project information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->